### PR TITLE
DEVOPS-14505: add ghrunner EBS snapshot build workflow + vendored snapshot-tool

### DIFF
--- a/.github/workflows/build-ghrunner-snapshot.yaml
+++ b/.github/workflows/build-ghrunner-snapshot.yaml
@@ -1,0 +1,193 @@
+name: Build ghrunner EBS snapshot & open PR
+
+# Builds a pre-warmed Bottlerocket data-volume EBS snapshot (cached container
+# images) for the github-actions Karpenter NodePool, then opens a SIGNED pull
+# request in analyticsMD/devops-multiaccount bumping `ebs_snapshot_id` in
+# stacks/internal/eks/uw2-prod-eks.yaml. A human reviews, runs `atmos plan`,
+# and applies via the normal TACOS flow.
+#
+# The snapshot ID is NOT written to SSM / read via Atmos `!store` on purpose:
+# we keep it a versioned, reviewable value in git (signed-commit policy).
+
+on:
+  workflow_dispatch:
+    inputs:
+      images:
+        description: "Comma-separated container images to cache into the snapshot"
+        required: true
+        default: "351480950201.dkr.ecr.us-west-2.amazonaws.com/github-runner:latest"
+      region:
+        description: "AWS region to build the snapshot in"
+        required: true
+        default: "us-west-2"
+      bottlerocket_ami_param:
+        description: "SSM param path for the Bottlerocket AMI (must match the cluster k8s version)"
+        required: true
+        default: "/aws/service/bottlerocket/aws-k8s-1.33/x86_64/latest/image_id"
+      snapshot_size:
+        description: "Builder data-volume size in GiB (must fit all cached images)"
+        required: true
+        default: "200"
+      instance_role:
+        description: "Existing IAM role for the builder instance (-R); reused so no role is created"
+        required: true
+        default: "KarpenterNodeRole-prod-eks-cluster"
+      subnet_id:
+        description: "Subnet ID for the builder instance (private subnet, no public IP)"
+        required: true
+        default: "subnet-071a8bf1ba92508f3"
+      security_group_id:
+        description: "Security group ID for the builder instance (blank = default VPC SG)"
+        required: false
+        default: ""
+
+env:
+  TARGET_REPO: analyticsMD/devops-multiaccount
+  TARGET_FILE: stacks/internal/eks/uw2-prod-eks.yaml
+  YQ_PATH: .components.helmfile.karpenter-config-github-actions.vars.ebs_snapshot_id
+  SLACK_CHANNEL_ID: C0830SADR0X # devops-github-actions
+  # Snapshot builder is vendored at snapshot-tool/ (see snapshot-tool/UPSTREAM).
+
+jobs:
+  build-snapshot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC for snapshot.sh
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate via GitHub Actions OIDC (auth role)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::351480950201:role/qv-internal-github-actions-auth-role
+          aws-region: ${{ github.event.inputs.region }}
+
+      - name: Chain into snapshot-build role with repository session tag
+        # Mirrors buid-push-image.yaml's role-chaining pattern. The role name ends
+        # in -gha-deploy-role so the shared auth role's PermitAssumeDeployRoles policy
+        # already allows chaining into it (defined in devops-multiaccount
+        # stacks/internal/common/uw2-github-actions.yaml).
+        run: |
+          CREDS=$(aws sts assume-role \
+            --role-arn arn:aws:iam::351480950201:role/qv-internal-github-actions-snapshot-gha-deploy-role \
+            --role-session-name github-runner-snapshot-build \
+            --tags "Key=repository,Value=${{ github.repository }}")
+          KEY=$(echo "$CREDS" | jq -r .Credentials.AccessKeyId)
+          SECRET=$(echo "$CREDS" | jq -r .Credentials.SecretAccessKey)
+          TOKEN=$(echo "$CREDS" | jq -r .Credentials.SessionToken)
+          echo "::add-mask::$KEY"
+          echo "::add-mask::$SECRET"
+          echo "::add-mask::$TOKEN"
+          {
+            echo "AWS_ACCESS_KEY_ID=$KEY"
+            echo "AWS_SECRET_ACCESS_KEY=$SECRET"
+            echo "AWS_SESSION_TOKEN=$TOKEN"
+          } >> "$GITHUB_ENV"
+
+      - name: Build EBS snapshot
+        id: snapshot
+        working-directory: snapshot-tool
+        run: |
+          ARGS=(-q -r "${{ github.event.inputs.region }}" \
+                -a "${{ github.event.inputs.bottlerocket_ami_param }}" \
+                -s "${{ github.event.inputs.snapshot_size }}" \
+                -R "${{ github.event.inputs.instance_role }}" \
+                -sn "${{ github.event.inputs.subnet_id }}" \
+                -p false)
+          [ -n "${{ github.event.inputs.security_group_id }}" ] && ARGS+=(-sg "${{ github.event.inputs.security_group_id }}")
+          # -q prints ONLY the snapshot id to stdout; logs go to stderr.
+          SNAP_ID=$(./snapshot.sh "${ARGS[@]}" "${{ github.event.inputs.images }}")
+          echo "Built snapshot: $SNAP_ID"
+          echo "snap_id=$SNAP_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token (scoped to devops-multiaccount)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PEM }}
+          owner: analyticsMD
+          repositories: devops-multiaccount
+
+      - name: Checkout devops-multiaccount
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TARGET_REPO }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: devops-multiaccount
+
+      - name: Install yq (mikefarah)
+        uses: mikefarah/yq@v4.44.3
+
+      - name: Update ebs_snapshot_id
+        working-directory: devops-multiaccount
+        env:
+          SNAP_ID: ${{ steps.snapshot.outputs.snap_id }}
+        run: |
+          yq -i "${YQ_PATH} = strenv(SNAP_ID)" "$TARGET_FILE"
+          git --no-pager diff -- "$TARGET_FILE"
+
+      - name: Open signed PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: devops-multiaccount
+          sign-commits: true # API-created commit → signed by GitHub → passes branch protection
+          branch: chore/ghrunners-ebs-snapshot
+          delete-branch: true
+          commit-message: "chore: bump ghrunners EBS snapshot to ${{ steps.snapshot.outputs.snap_id }}"
+          title: "chore: bump ghrunners EBS snapshot to ${{ steps.snapshot.outputs.snap_id }}"
+          body: |
+            Automated bump of the github-actions Karpenter NodePool pre-warmed
+            EBS snapshot.
+
+            - New snapshot: `${{ steps.snapshot.outputs.snap_id }}`
+            - Built from: `${{ github.repository }}` run ${{ github.run_id }}
+            - Images cached: `${{ github.event.inputs.images }}`
+
+            Review, then run `atmos plan` and apply via TACOS.
+
+      - name: Slack notify (success)
+        if: success()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "ghrunner EBS snapshot PR opened",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "✅ *ghrunner EBS snapshot built:* `${{ steps.snapshot.outputs.snap_id }}`\nPR opened in *${{ env.TARGET_REPO }}* — review + `atmos plan` to roll out."
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Slack notify (failure)
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "ghrunner EBS snapshot build failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "❌ *ghrunner EBS snapshot workflow failed*\n*Repo:* ${{ github.repository }}\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n<!channel>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/snapshot-tool/LICENSE
+++ b/snapshot-tool/LICENSE
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/snapshot-tool/UPSTREAM
+++ b/snapshot-tool/UPSTREAM
@@ -1,0 +1,7 @@
+Source:  https://github.com/aws-samples/bottlerocket-images-cache
+Commit:  e98a993afbe66dba17ebb27c9a89440a854bb8ee
+License: MIT-0 (see LICENSE)
+
+Vendored copy of the Bottlerocket image-cache snapshot builder.
+Do not edit in place — to update, re-copy snapshot.sh + ebs-snapshot-instance.yaml
+from upstream at a newer commit in a reviewed PR and bump the Commit line above.

--- a/snapshot-tool/ebs-snapshot-instance.yaml
+++ b/snapshot-tool/ebs-snapshot-instance.yaml
@@ -1,0 +1,134 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+Description: Bottlerocket instance to snapshot data volume with configurable network settings.
+
+Parameters:
+  AmiID:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Description: "The ID of the AMI."
+    Default: /aws/service/bottlerocket/aws-k8s-1.27/x86_64/latest/image_id
+  InstanceType:
+    Type: String
+    Description: "EC2 instance type to launch"
+    Default: m5.large
+  InstanceRole:
+    Type: String
+    Description: "Name of IAM Role used in instance"
+    Default: NONE
+  Encrypt:
+    Type: String
+    Description: "Encrypt the EBS volumes"
+    Default: NONE
+  KMSId:
+    Type: String
+    Description: "Id of the KMS Key used for the snapshot"
+    Default: NONE
+  SnapshotSize:
+    Type: Number
+    Description: "Size of the target snapshot"
+    Default: 50
+  SecurityGroupId:
+    Type: String
+    Description: "Optional Security Group ID. If not provided, the default VPC security group will be used."
+    Default: NONE
+  SubnetId:
+    Type: String
+    Description: "Optional Subnet ID. If not provided, a subnet from the default VPC will be used."
+    Default: NONE
+  AssociatePublicIpAddress:
+    Type: String
+    Description: "Whether to associate a public IP address to the instance"
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+
+Conditions:
+  CreateNewIAMRole: !Equals [!Ref InstanceRole, NONE]
+  UseCustomKMSId: !Not [!Equals [!Ref KMSId, NONE]]
+  Encrypt: !Not [!Equals [!Ref Encrypt, NONE]]
+  UseCustomSecurityGroup: !Not [!Equals [!Ref SecurityGroupId, NONE]]
+  UseCustomSubnet: !Not [!Equals [!Ref SubnetId, NONE]]
+
+Resources:
+  BottlerocketNodeRole:
+    Type: "AWS::IAM::Role"
+    Condition: CreateNewIAMRole
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                !Sub "ec2.${AWS::URLSuffix}"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+
+  BottlerocketNodeInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: "/"
+      Roles:
+        - !If [CreateNewIAMRole, !Ref BottlerocketNodeRole, !Ref InstanceRole]
+
+  BottlerocketLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: !Ref AmiID
+        InstanceType: !Ref InstanceType
+        IamInstanceProfile:
+          Name: !Ref BottlerocketNodeInstanceProfile
+        EbsOptimized: true
+        UserData:
+          Fn::Base64: |
+            [settings.host-containers.admin]
+            enabled = true
+        BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 10
+            VolumeType: gp3
+            DeleteOnTermination: true
+        - DeviceName: /dev/xvdb
+          Ebs:
+            VolumeSize: !Ref SnapshotSize
+            VolumeType: gp3
+            Encrypted:
+              Fn::If:
+                - Encrypt
+                - true
+                - false
+            KmsKeyId:
+              Fn::If:
+                - UseCustomKMSId
+                - !Ref KMSId
+                - !Ref AWS::NoValue
+            Throughput: 1000
+            Iops: 4000
+            DeleteOnTermination: true
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: !Ref AssociatePublicIpAddress
+            DeviceIndex: "0"
+            Groups:
+              - !If [UseCustomSecurityGroup, !Ref SecurityGroupId, !Ref 'AWS::NoValue']
+            SubnetId: !If [UseCustomSubnet, !Ref SubnetId, !Ref 'AWS::NoValue']
+
+  BottlerocketInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      LaunchTemplate:
+        LaunchTemplateId: !Ref BottlerocketLaunchTemplate
+        Version: !GetAtt BottlerocketLaunchTemplate.LatestVersionNumber
+
+Outputs:
+  InstanceId:
+    Value: !Ref BottlerocketInstance
+    Description: Instance Id

--- a/snapshot-tool/snapshot.sh
+++ b/snapshot-tool/snapshot.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+set -e
+
+function print_help {
+    echo "usage: $0 [options] <comma seperated container images>"
+    echo "Build EBS snapshot for Bottlerocket data volume with cached container images"
+    echo "Options:"
+    echo "-h,--help Print this help."
+    echo "-A, --arch Set image architectures to pull (comma-separated). (default: amd64)"
+    echo "-r,--region Set AWS region to build the EBS snapshot. (default: use environment variable of AWS_DEFAULT_REGION or IMDS)"
+    echo "-a,--ami Set SSM Parameter path for Bottlerocket ID. (default: /aws/service/bottlerocket/aws-k8s-1.27/x86_64/latest/image_id)"
+    echo "-i,--instance-type Set EC2 instance type to build this snapshot. (default: m5.large)"
+    echo "-e,--encrypt Encrypt the generated snapshot. (default: false)"
+    echo "-k,--kms-id Use a specific KMS Key Id to encrypt this snapshot, should use together with -e"
+    echo "-s,--snapshot-size Use a specific volume size (in GiB) for this snapshot. (default: 50)"
+    echo "-R,--instance-role Name of existing IAM role for created EC2 instance. (default: Create on launching)"
+    echo "-q,--quiet Redirect output to stderr and output generated snapshot ID to stdout only. (default: false)"
+    echo "-sg,--security-group-id Set a specific Security Group ID for the instance. (default: use default VPC security group)"
+    echo "-sn,--subnet-id Set a specific Subnet ID for the instance. (default: use default VPC subnet)"
+    echo "-op,--output-parameter-name Set the SSM parameter name to store the generated snapshot ID. (default: NONE)"
+    echo "-p,--public-ip Associate a public IP address with the instance. (default: true)"
+}
+
+QUIET=false
+ASSOCIATE_PUBLIC_IP=true
+
+function log() {
+    datestring=$(date +"%Y-%m-%d %H:%M:%S")
+    if [ "$QUIET" = false ]; then
+        echo -e "$datestring I - $*"
+    else
+        echo -e "$datestring I - $*" >&2
+    fi
+}
+
+function logerror() {
+    datestring=$(date +"%Y-%m-%d %H:%M:%S")
+    echo -e "$datestring E - $*" >&2
+}
+
+function cleanup() {
+    log "Cleaning up stack $1..."
+    if aws cloudformation describe-stacks --stack-name "$1" &> /dev/null; then
+        aws cloudformation delete-stack --stack-name "$1"
+        log "Stack deletion initiated."
+    else
+        log "Stack $1 not found or already deleted."
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -h|--help)
+            print_help
+            exit 1
+            ;;
+        -r|--region)
+            AWS_DEFAULT_REGION="$2"
+            shift
+            shift
+            ;;
+        -a|--ami)
+            AMI_ID="$2"
+            shift
+            shift
+            ;;
+        -i|--instance-type)
+            INSTANCE_TYPE="$2"
+            shift
+            shift
+            ;;
+        -e|--encrypt)
+            ENCRYPT=true
+            shift
+            ;;
+        -k|--kms-id)
+            if [ -n "$ENCRYPT" ] && [[ $ENCRYPT == true ]]; then
+              KMS_ID="$2"
+            else
+              logerror "KMS Key should only be specified when snapshot is encrypted. (-e)"
+              exit 2
+            fi
+            shift
+            shift
+            ;;
+        -s|--snapshot-size)
+            SNAPSHOT_SIZE="$2"
+            shift
+            shift
+            ;;
+        -R|--instance-role)
+            INSTANCE_ROLE="$2"
+            shift
+            shift
+            ;;
+        -q|--quiet)
+            QUIET=true
+            shift
+            ;;
+        -sg|--security-group-id)
+            SECURITY_GROUP_ID="$2"
+            shift
+            shift
+            ;;
+        -sn|--subnet-id)
+            SUBNET_ID="$2"
+            shift
+            shift
+            ;;
+        -p|--public-ip)
+            ASSOCIATE_PUBLIC_IP="$2"
+            shift
+            shift
+            ;;
+        -op|--output-parameter-name)
+            OUTPUT_PARAMETER_NAME="$2"
+            shift
+            shift
+            ;;
+        -A|--arch)
+            ARCHITECTURES="$2"
+            shift
+            shift
+            ;;
+        *)
+            POSITIONAL+=("$1") # save it in an array for later
+            shift # past argument
+            ;;
+    esac
+done
+
+set +u
+set -- "${POSITIONAL[@]}" # restore positional parameters
+IMAGES="$1"
+set -u
+
+AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-$(aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')}
+AMI_ID=${AMI_ID:-/aws/service/bottlerocket/aws-k8s-1.27/x86_64/latest/image_id}
+INSTANCE_TYPE=${INSTANCE_TYPE:-m5.large}
+INSTANCE_ROLE=${INSTANCE_ROLE:-NONE}
+ENCRYPT=${ENCRYPT:-NONE}
+KMS_ID=${KMS_ID:-NONE}
+SNAPSHOT_SIZE=${SNAPSHOT_SIZE:-50}
+SECURITY_GROUP_ID=${SECURITY_GROUP_ID:-NONE}
+SUBNET_ID=${SUBNET_ID:-NONE}
+ASSOCIATE_PUBLIC_IP=${ASSOCIATE_PUBLIC_IP:-true}
+OUTPUT_PARAMETER_NAME=${OUTPUT_PARAMETER_NAME:-NONE}
+ARCHITECTURES=${ARCHITECTURES:-amd64}
+SCRIPTPATH=$(dirname "$0")
+CTR_CMD="apiclient exec admin sheltie ctr -a /run/containerd/containerd.sock -n k8s.io"
+
+if [ -z "${AWS_DEFAULT_REGION}" ]; then
+    logerror "Please set AWS region"
+    exit 1
+fi
+
+if [ -z "${IMAGES}" ]; then
+    logerror "Please set images list"
+    exit 1
+fi
+
+# Validate image names to prevent injection
+for img in $(echo "$IMAGES" | tr ',' ' '); do
+    if [[ ! "$img" =~ ^[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+$ ]] && [[ ! "$img" =~ ^[a-zA-Z0-9._/-]+(:[a-zA-Z0-9._-]+)?@sha256:[a-f0-9]{64}$ ]]; then
+        logerror "Invalid image format: $img"
+        exit 1
+    fi
+done
+
+# Validate architectures
+for arch in $(echo "$ARCHITECTURES" | tr ',' ' '); do
+    if [[ ! "$arch" =~ ^(amd64|arm64|386|arm)$ ]]; then
+        logerror "Invalid architecture: $arch"
+        exit 1
+    fi
+done
+
+# Use read -a to create arrays from comma-separated strings
+IFS=',' read -r -a IMAGES_LIST <<< "$IMAGES"
+IFS=',' read -r -a ARCH_LIST <<< "$ARCHITECTURES"
+# Validate AWS CLI is available and configured
+if ! command -v aws &> /dev/null; then
+    logerror "AWS CLI is not installed or not in PATH"
+    exit 1
+fi
+
+# Test AWS credentials
+if ! aws sts get-caller-identity &> /dev/null; then
+    logerror "AWS credentials not configured or invalid"
+    exit 1
+fi
+
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}"
+
+##############################################################################################
+export AWS_PAGER=""
+
+# launch EC2
+RAND=$(od -An -N2 -i /dev/urandom | tr -d ' ' | cut -c1-4)
+CFN_STACK_NAME="Bottlerocket-ebs-snapshot-$RAND"
+log "[1/8] Deploying EC2 CFN stack $CFN_STACK_NAME ..."
+CFN_PARAMS="AmiID=$AMI_ID InstanceType=$INSTANCE_TYPE InstanceRole=$INSTANCE_ROLE Encrypt=$ENCRYPT KMSId=$KMS_ID SnapshotSize=$SNAPSHOT_SIZE SecurityGroupId=$SECURITY_GROUP_ID SubnetId=$SUBNET_ID AssociatePublicIpAddress=$ASSOCIATE_PUBLIC_IP"
+
+# log $CFN_PARAMS
+
+if ! aws cloudformation deploy \
+  --stack-name "$CFN_STACK_NAME" \
+  --template-file "$SCRIPTPATH/ebs-snapshot-instance.yaml" \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides $CFN_PARAMS > /dev/null; then
+    logerror "Failed to deploy CloudFormation stack"
+    exit 1
+fi
+
+INSTANCE_ID=$(aws cloudformation describe-stacks --stack-name "$CFN_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" --output text)
+
+# wait for SSM ready
+log "[2/8] Launching SSM ."
+while [[ $(aws ssm describe-instance-information --filters "Key=InstanceIds,Values=$INSTANCE_ID" --query "InstanceInformationList[0].PingStatus" --output text) != "Online" ]]
+do
+   sleep 5
+done
+log "SSM launched in instance $INSTANCE_ID."
+
+# stop kubelet.service
+log "[3/8] Stopping kubelet.service .."
+CMDID=$(aws ssm send-command --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunShellScript" --comment "Stop kubelet" \
+    --parameters commands="apiclient exec admin sheltie systemctl stop kubelet" \
+    --query "Command.CommandId" --output text)
+aws ssm wait command-executed --command-id "$CMDID" --instance-id "$INSTANCE_ID" > /dev/null
+log "Kubelet service stopped."
+
+# cleanup existing images
+log "[4/8] Cleanup existing images .."
+CMDID=$(aws ssm send-command --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunShellScript" --comment "Cleanup existing images" \
+    --parameters commands="$CTR_CMD images rm \$($CTR_CMD images ls -q)" \
+    --query "Command.CommandId" --output text)
+aws ssm wait command-executed --command-id "$CMDID" --instance-id "$INSTANCE_ID" > /dev/null
+log "Existing images cleaned"
+
+# pull images
+log "[5/8] Pulling images:"
+for IMG in "${IMAGES_LIST[@]}"
+do
+    ECR_REGION=$(echo "$IMG" | sed -n "s/^[0-9]*\.dkr\.ecr\.\([a-z1-9-]*\)\.amazonaws\.com.*$/\1/p")
+    [ -n "$ECR_REGION" ] && ECRPWD="--u AWS:$(aws ecr get-login-password --region "$ECR_REGION")" || ECRPWD=""
+    for PLATFORM in "${ARCH_LIST[@]}"
+    do
+        log "Pulling $IMG - $PLATFORM ... "
+        COMMAND="$CTR_CMD images pull --label io.cri-containerd.image=managed --platform $PLATFORM $ECRPWD $IMG"
+        CMDID=$(aws ssm send-command --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" --comment "Pull Image ${IMG:0:75} - $PLATFORM" \
+            --parameters commands="$COMMAND" \
+            --query "Command.CommandId" --output text)
+        # Wait with timeout to prevent infinite loops
+        WAIT_COUNT=0
+        MAX_WAIT=60  # 5 minutes max wait
+        until aws ssm wait command-executed --command-id "$CMDID" --instance-id "$INSTANCE_ID" &> /dev/null && log "$IMG - $PLATFORM pulled. "
+        do
+            sleep 5
+            WAIT_COUNT=$((WAIT_COUNT + 1))
+            if [ $WAIT_COUNT -gt $MAX_WAIT ]; then
+                logerror "Timeout waiting for image $IMG to pull"
+                cleanup "$CFN_STACK_NAME"
+                exit 1
+            fi
+            if [ "$(aws ssm get-command-invocation --command-id "$CMDID" --instance-id "$INSTANCE_ID" --output text --query Status)" == "Failed" ]; then
+                REASON=$(aws ssm get-command-invocation --command-id "$CMDID" --instance-id "$INSTANCE_ID" --output text --query StandardOutputContent)
+                logerror "Image $IMG pulling failed with following output: "
+                logerror "$REASON"
+                cleanup "$CFN_STACK_NAME"
+                exit 1
+            fi
+        done
+    done
+done
+
+# stop EC2
+log "[6/8] Stopping instance ... "
+aws ec2 stop-instances --instance-ids "$INSTANCE_ID" --output text > /dev/null
+aws ec2 wait instance-stopped --instance-ids "$INSTANCE_ID" > /dev/null && log "Instance $INSTANCE_ID stopped"
+
+# create EBS snapshot
+log "[7/8] Creating snapshot ... "
+DATA_VOLUME_ID=$(aws ec2 describe-instances --instance-id "$INSTANCE_ID" --query "Reservations[0].Instances[0].BlockDeviceMappings[?DeviceName=='/dev/xvdb'].Ebs.VolumeId" --output text)
+SNAPSHOT_ID=$(aws ec2 create-snapshot --volume-id "$DATA_VOLUME_ID" --tag-specifications 'ResourceType=snapshot,Tags=[{Key=Name,Value=Bottlerocket Data Volume}]' --description "Bottlerocket Data Volume snapshot with ${IMAGES:0:200}" --query "SnapshotId" --output text)
+until aws ec2 wait snapshot-completed --snapshot-ids "$SNAPSHOT_ID" &> /dev/null && log "Snapshot $SNAPSHOT_ID generated."
+do
+    sleep 5
+done
+
+# destroy temporary instance
+log "[8/8] Cleanup."
+cleanup "$CFN_STACK_NAME"
+
+# write snapshot-id to parameter store
+if [ "$OUTPUT_PARAMETER_NAME" != "NONE" ]; then
+    log "Updating SSM parameter $OUTPUT_PARAMETER_NAME"
+    aws ssm put-parameter --name "$OUTPUT_PARAMETER_NAME" --value "$SNAPSHOT_ID" --type String --overwrite
+fi
+
+# done!
+log "--------------------------------------------------"
+log "All done! Created snapshot in $AWS_DEFAULT_REGION: $SNAPSHOT_ID"
+if [ $QUIET = true ]; then
+    echo "$SNAPSHOT_ID"
+fi


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow that builds the github-actions Karpenter NodePool's pre-warmed Bottlerocket EBS snapshot and opens a **signed** PR in `analyticsMD/devops-multiaccount` bumping `ebs_snapshot_id` — replacing the current manual snapshot build + manual commit (snapshot v4 → v5 → v6 → v7).

### What it does
1. Assumes AWS via the existing OIDC `auth` role, then chains into `qv-internal-github-actions-snapshot-gha-deploy-role` (repository session tag) — same pattern as the ECR push job.
2. Runs the vendored `snapshot-tool/snapshot.sh -q` (defaults match the documented v7 build: k8s 1.33 AMI, `-s 200`, `-R KarpenterNodeRole-prod-eks-cluster`, subnet `subnet-071a8bf1ba92508f3`, `-p false`, image `…/github-runner:latest`).
3. Mints a GitHub App token scoped to `devops-multiaccount`, edits the one line with `yq`, and opens a PR via `peter-evans/create-pull-request@v7` with `sign-commits: true` (API-created commit → signed by GitHub → satisfies the require-signed-commits branch protection). Slack-notifies `#devops-github-actions`.

### Vendored tool
`snapshot-tool/` is a pinned, reviewed copy of `aws-samples/bottlerocket-images-cache` @ `e98a993afbe66dba17ebb27c9a89440a854bb8ee` (MIT-0; see `snapshot-tool/UPSTREAM`). Vendored rather than cloned at runtime so no un-reviewed third-party code is fetched during a run. `snapshot.sh` deploys `ebs-snapshot-instance.yaml` via `$SCRIPTPATH`, so the two stay co-located.

## Prerequisites before this can run
- **devops-multiaccount #3524** — the `snapshot-gha-deploy` IAM role (planned clean: Create 2 / Update 0 / Destroy 0); must be applied.
- **GitHub App `qv-ghrunners-snapshot-bot`** (org owner) — `Contents: RW` + `Pull requests: RW`, installed on `devops-multiaccount` only.
- Repo secrets `GH_APP_ID` + `GH_APP_PEM` on this repo.

## Notes
- Does not auto-merge anything — the downstream PR goes through the normal TACOS review/plan/apply in devops-multiaccount.
- The snapshot ID stays a versioned, reviewable value in git (we explicitly rejected an SSM `!store` "shadow change" approach).
