### PR TITLE
DEVOPS-14739: surgical sed edit for ebs_snapshot_id bump (avoid yq reformatting)

### DIFF
--- a/.github/workflows/build-ghrunner-snapshot.yaml
+++ b/.github/workflows/build-ghrunner-snapshot.yaml
@@ -44,7 +44,6 @@ on:
 env:
   TARGET_REPO: analyticsMD/devops-multiaccount
   TARGET_FILE: stacks/internal/eks/uw2-prod-eks.yaml
-  YQ_PATH: .components.helmfile.karpenter-config-github-actions.vars.ebs_snapshot_id
   SLACK_CHANNEL_ID: C0830SADR0X # devops-github-actions
   # Snapshot builder is vendored at snapshot-tool/ (see snapshot-tool/UPSTREAM).
 
@@ -119,15 +118,21 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: devops-multiaccount
 
-      - name: Install yq (mikefarah)
-        uses: mikefarah/yq@v4.44.3
-
       - name: Update ebs_snapshot_id
         working-directory: devops-multiaccount
         env:
           SNAP_ID: ${{ steps.snapshot.outputs.snap_id }}
         run: |
-          yq -i "${YQ_PATH} = strenv(SNAP_ID)" "$TARGET_FILE"
+          # Surgical single-line replace. `yq -i` rewrites the file in its canonical
+          # form and strips blank lines between mappings, producing a noisy diff that
+          # fails the repo's "scoped specifically" review gate. ebs_snapshot_id is
+          # unique in the file, so a targeted sed keeps the diff to exactly one line.
+          matches=$(grep -cE '^[[:space:]]*ebs_snapshot_id:' "$TARGET_FILE")
+          if [ "$matches" -ne 1 ]; then
+            echo "::error::expected exactly 1 ebs_snapshot_id line in $TARGET_FILE, found $matches"
+            exit 1
+          fi
+          sed -i -E "s|^([[:space:]]*ebs_snapshot_id:[[:space:]]*).*|\1\"${SNAP_ID}\"|" "$TARGET_FILE"
           git --no-pager diff -- "$TARGET_FILE"
 
       - name: Open signed PR


### PR DESCRIPTION
## Summary

The snapshot bump step used `yq -i`, which rewrites `uw2-prod-eks.yaml` in yq's canonical form and **strips blank lines between mappings**. The first live auto-PR (devops-multiaccount #3553) came out as `1 insertion, 23 deletions` — the correct one-line snapshot bump plus 22 unrelated blank-line deletions across the file. That fails devops-multiaccount's "scoped specifically within the context of the change" review gate and makes every auto-PR noisy/conflict-prone.

## Fix

Replace the `yq -i` rewrite with a surgical `sed` on the (unique) `ebs_snapshot_id:` line, guarded by a check that exactly one such line exists. Removes the now-unused `mikefarah/yq` install step and `YQ_PATH` env var.

Verified locally against the real target file: produces exactly `1 insertion, 1 deletion` (no reformatting); the uniqueness guard matches 1 line.

## Context

Follow-up to the snapshot automation (DEVOPS-14505 / role fix DEVOPS-14739). devops-multiaccount #3553 (the churny auto-PR) is being closed; a re-run after this merges should produce a clean one-line bump PR.