### PR TITLE
DEVOPS-14739: auto-trigger snapshot build on image rebuild + prune old snapshots

### DIFF
--- a/.github/workflows/build-ghrunner-snapshot.yaml
+++ b/.github/workflows/build-ghrunner-snapshot.yaml
@@ -40,15 +40,38 @@ on:
         description: "Security group ID for the builder instance (blank = default VPC SG)"
         required: false
         default: ""
+  # Auto-rebuild when the runner image changes. "Build and Push Docker Image"
+  # runs on a 1st/15th cron (~2x/month) + manual dispatch; chaining off its
+  # completion keeps the cached snapshot in sync with the image it caches.
+  workflow_run:
+    workflows: ["Build and Push Docker Image"]
+    types: [completed]
+
+# Never run two builders concurrently — each spins up a CFN stack and opens a PR.
+concurrency:
+  group: ghrunner-snapshot-build
+  cancel-in-progress: false
 
 env:
   TARGET_REPO: analyticsMD/devops-multiaccount
   TARGET_FILE: stacks/internal/eks/uw2-prod-eks.yaml
   SLACK_CHANNEL_ID: C0830SADR0X # devops-github-actions
   # Snapshot builder is vendored at snapshot-tool/ (see snapshot-tool/UPSTREAM).
+  # Build-parameter defaults. workflow_dispatch overrides these via inputs; the
+  # workflow_run (image-rebuild) trigger carries NO inputs, so these are used.
+  DEFAULT_IMAGES: "351480950201.dkr.ecr.us-west-2.amazonaws.com/github-runner:latest"
+  DEFAULT_REGION: "us-west-2"
+  DEFAULT_BR_AMI_PARAM: "/aws/service/bottlerocket/aws-k8s-1.33/x86_64/latest/image_id"
+  DEFAULT_SNAPSHOT_SIZE: "200"
+  DEFAULT_INSTANCE_ROLE: "KarpenterNodeRole-prod-eks-cluster"
+  DEFAULT_SUBNET_ID: "subnet-071a8bf1ba92508f3"
 
 jobs:
   build-snapshot:
+    # On workflow_run, only proceed if the image build succeeded; always run for manual dispatch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,11 +81,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Resolve build parameters
+        # workflow_run carries no inputs — fall back to the DEFAULT_* env so the
+        # image-triggered rebuild uses the same parameters as a default dispatch.
+        run: |
+          {
+            echo "REGION=${{ github.event.inputs.region || env.DEFAULT_REGION }}"
+            echo "IMAGES=${{ github.event.inputs.images || env.DEFAULT_IMAGES }}"
+            echo "BR_AMI_PARAM=${{ github.event.inputs.bottlerocket_ami_param || env.DEFAULT_BR_AMI_PARAM }}"
+            echo "SNAPSHOT_SIZE=${{ github.event.inputs.snapshot_size || env.DEFAULT_SNAPSHOT_SIZE }}"
+            echo "INSTANCE_ROLE=${{ github.event.inputs.instance_role || env.DEFAULT_INSTANCE_ROLE }}"
+            echo "SUBNET_ID=${{ github.event.inputs.subnet_id || env.DEFAULT_SUBNET_ID }}"
+            echo "SECURITY_GROUP_ID=${{ github.event.inputs.security_group_id }}"
+          } >> "$GITHUB_ENV"
+
       - name: Authenticate via GitHub Actions OIDC (auth role)
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::351480950201:role/qv-internal-github-actions-auth-role
-          aws-region: ${{ github.event.inputs.region }}
+          aws-region: ${{ env.REGION }}
 
       - name: Chain into snapshot-build role with repository session tag
         # Mirrors buid-push-image.yaml's role-chaining pattern. The role name ends
@@ -90,15 +127,15 @@ jobs:
         id: snapshot
         working-directory: snapshot-tool
         run: |
-          ARGS=(-q -r "${{ github.event.inputs.region }}" \
-                -a "${{ github.event.inputs.bottlerocket_ami_param }}" \
-                -s "${{ github.event.inputs.snapshot_size }}" \
-                -R "${{ github.event.inputs.instance_role }}" \
-                -sn "${{ github.event.inputs.subnet_id }}" \
+          ARGS=(-q -r "$REGION" \
+                -a "$BR_AMI_PARAM" \
+                -s "$SNAPSHOT_SIZE" \
+                -R "$INSTANCE_ROLE" \
+                -sn "$SUBNET_ID" \
                 -p false)
-          [ -n "${{ github.event.inputs.security_group_id }}" ] && ARGS+=(-sg "${{ github.event.inputs.security_group_id }}")
+          [ -n "$SECURITY_GROUP_ID" ] && ARGS+=(-sg "$SECURITY_GROUP_ID")
           # -q prints ONLY the snapshot id to stdout; logs go to stderr.
-          SNAP_ID=$(./snapshot.sh "${ARGS[@]}" "${{ github.event.inputs.images }}")
+          SNAP_ID=$(./snapshot.sh "${ARGS[@]}" "$IMAGES")
           echo "Built snapshot: $SNAP_ID"
           echo "snap_id=$SNAP_ID" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-ghrunner-snapshot.yaml
+++ b/.github/workflows/build-ghrunner-snapshot.yaml
@@ -40,12 +40,14 @@ on:
         description: "Security group ID for the builder instance (blank = default VPC SG)"
         required: false
         default: ""
-  # Auto-rebuild when the runner image changes. "Build and Push Docker Image"
-  # runs on a 1st/15th cron (~2x/month) + manual dispatch; chaining off its
-  # completion keeps the cached snapshot in sync with the image it caches.
+  # Auto-rebuild when the runner image changes on main. "Build and Push Docker
+  # Image" runs on a 1st/15th cron (~2x/month) + manual dispatch; chaining off its
+  # completion keeps the cached snapshot in sync with the image it caches. The
+  # `branches: [main]` filter restricts this to image builds that ran on main.
   workflow_run:
     workflows: ["Build and Push Docker Image"]
     types: [completed]
+    branches: [main]
 
 # Never run two builders concurrently — each spins up a CFN stack and opens a PR.
 concurrency:
@@ -68,10 +70,13 @@ env:
 
 jobs:
   build-snapshot:
-    # On workflow_run, only proceed if the image build succeeded; always run for manual dispatch.
+    # Manual dispatch always runs. On workflow_run, only proceed when the image
+    # build on main succeeded AND was cron-triggered (the scheduled rebuild) — so
+    # manual/one-off image rebuilds don't also kick off a snapshot build.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'schedule')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -160,19 +165,24 @@ jobs:
         env:
           SNAP_ID: ${{ steps.snapshot.outputs.snap_id }}
         run: |
-          # Surgical single-line replace. `yq -i` rewrites the file in its canonical
-          # form and strips blank lines between mappings, producing a noisy diff that
-          # fails the repo's "scoped specifically" review gate. ebs_snapshot_id is
-          # unique in the file, so a targeted sed keeps the diff to exactly one line.
-          matches=$(grep -cE '^[[:space:]]*ebs_snapshot_id:' "$TARGET_FILE")
+          # Surgical single-line replace keyed off the `managed-by` marker comment on
+          # the target line. `yq -i` would rewrite the file in canonical form (stripping
+          # blank lines between mappings and expanding YAML anchors), producing a noisy
+          # diff that fails the repo's "scoped specifically" review gate. Keying the sed
+          # off the marker keeps the diff to exactly one line and stays correct if another
+          # Karpenter NodePool later adds its own ebs_snapshot_id.
+          MARKER='managed-by: build-ghrunner-snapshot'
+          matches=$(grep -cE "ebs_snapshot_id:.*# *${MARKER}" "$TARGET_FILE" || true)
           if [ "$matches" -ne 1 ]; then
-            echo "::error::expected exactly 1 ebs_snapshot_id line in $TARGET_FILE, found $matches"
+            echo "::error::expected exactly 1 ebs_snapshot_id line marked '${MARKER}' in $TARGET_FILE, found $matches"
             exit 1
           fi
-          # Capture the currently-live id (pre-bump) so the prune step never deletes it.
-          PREV_SNAP_ID=$(grep -oE 'snap-[0-9a-f]+' "$TARGET_FILE" | head -1)
+          # Capture the currently-live id (pre-bump) from the marked line so the prune
+          # step never deletes it.
+          PREV_SNAP_ID=$(grep -E "ebs_snapshot_id:.*# *${MARKER}" "$TARGET_FILE" | grep -oE 'snap-[0-9a-f]+')
           echo "PREV_SNAP_ID=$PREV_SNAP_ID" >> "$GITHUB_ENV"
-          sed -i -E "s|^([[:space:]]*ebs_snapshot_id:[[:space:]]*).*|\1\"${SNAP_ID}\"|" "$TARGET_FILE"
+          # Replace only the marked line, preserving the marker comment.
+          sed -i -E "s|^([[:space:]]*ebs_snapshot_id:[[:space:]]*)\"?snap-[0-9a-f]+\"?([[:space:]]*#.*${MARKER}.*)$|\1\"${SNAP_ID}\"\2|" "$TARGET_FILE"
           git --no-pager diff -- "$TARGET_FILE"
 
       - name: Open signed PR

--- a/.github/workflows/build-ghrunner-snapshot.yaml
+++ b/.github/workflows/build-ghrunner-snapshot.yaml
@@ -169,6 +169,9 @@ jobs:
             echo "::error::expected exactly 1 ebs_snapshot_id line in $TARGET_FILE, found $matches"
             exit 1
           fi
+          # Capture the currently-live id (pre-bump) so the prune step never deletes it.
+          PREV_SNAP_ID=$(grep -oE 'snap-[0-9a-f]+' "$TARGET_FILE" | head -1)
+          echo "PREV_SNAP_ID=$PREV_SNAP_ID" >> "$GITHUB_ENV"
           sed -i -E "s|^([[:space:]]*ebs_snapshot_id:[[:space:]]*).*|\1\"${SNAP_ID}\"|" "$TARGET_FILE"
           git --no-pager diff -- "$TARGET_FILE"
 
@@ -188,9 +191,35 @@ jobs:
 
             - New snapshot: `${{ steps.snapshot.outputs.snap_id }}`
             - Built from: `${{ github.repository }}` run ${{ github.run_id }}
-            - Images cached: `${{ github.event.inputs.images }}`
+            - Images cached: `${{ env.IMAGES }}`
 
             Review, then run `atmos plan` and apply via TACOS.
+
+      - name: Prune old snapshots (keep newest 3)
+        # Best-effort cleanup so snapshots don't accumulate (~2/month, 200 GiB each).
+        # Keeps the newest 3, and always protects the just-built id and the
+        # currently-live id. Bounded by the role's DeleteSnapshot tag/region condition.
+        continue-on-error: true
+        env:
+          KEEP: "3"
+          NEW_ID: ${{ steps.snapshot.outputs.snap_id }}
+        run: |
+          set -euo pipefail
+          mapfile -t SNAPS < <(aws ec2 describe-snapshots --owner-ids self --region "$REGION" \
+            --filters 'Name=tag:Name,Values=Bottlerocket Data Volume' \
+            --query 'reverse(sort_by(Snapshots,&StartTime))[].SnapshotId' --output text | tr '\t' '\n')
+          echo "Found ${#SNAPS[@]} snapshots; keeping newest $KEEP + live ($PREV_SNAP_ID) + new ($NEW_ID)"
+          i=0
+          for s in "${SNAPS[@]}"; do
+            [ -z "$s" ] && continue
+            i=$((i+1))
+            if [ "$i" -le "$KEEP" ] || [ "$s" = "$NEW_ID" ] || [ "$s" = "$PREV_SNAP_ID" ]; then
+              echo "keep  $s"; continue
+            fi
+            echo "prune $s"
+            aws ec2 delete-snapshot --region "$REGION" --snapshot-id "$s" \
+              || echo "::warning::failed to delete $s"
+          done
 
       - name: Slack notify (success)
         if: success()


### PR DESCRIPTION
## Summary

Two production-readiness additions to the snapshot workflow:

### 1. Auto-trigger on image rebuild (main + cron only)
- `workflow_run` chained off **"Build and Push Docker Image"** (`types: [completed]`, `branches: [main]`), which runs `0 0 1,15 * *` (~2x/month) + dispatch — so the snapshot tracks the image it caches. The `branches: [main]` filter keeps branch/PR image builds from triggering it.
- Job guard: manual dispatch always runs; on `workflow_run` it proceeds only when the image build **succeeded AND was cron-triggered** (`github.event.workflow_run.event == 'schedule'`) — so manual/one-off image rebuilds don't also kick off a snapshot build.
- `concurrency` group `ghrunner-snapshot-build` (no cancel) so two builders can't collide.
- No-inputs handling: `workflow_run` carries no `inputs`, so `DEFAULT_*` env + a "Resolve build parameters" step (`inputs.X || env.DEFAULT_X`) feed the build; manual overrides still work.

### 2. Prune old snapshots
- New "Prune old snapshots" step (`continue-on-error`) keeps the **newest 3**, always protecting the just-built id and the currently-live id (captured pre-bump). Stops the ~2/month, 200 GiB accumulation.

### 3. Marker-keyed `ebs_snapshot_id` bump
- The bump now keys off a `# managed-by: build-ghrunner-snapshot` marker comment on the target line instead of assuming a single `ebs_snapshot_id`. It validates exactly one marked line (**fail-closed** on 0 or 2+), captures the pre-bump id from that line, and `sed`-replaces only it — so it stays correct if another Karpenter NodePool later adds its own `ebs_snapshot_id`, and keeps the PR diff to one line (no `yq` anchor-reflow).

### Dependency & sequencing
- **Depends on devops-multiaccount #3571**, which now (a) grants `ec2:DeleteSnapshot` (tag+region scoped) for the prune step and (b) adds the `# managed-by: build-ghrunner-snapshot` marker to the target line. **Merge #3571 to `main` first** — the bump step fail-closes (errors, opens no PR) if the marker isn't present yet, and the prune step no-ops without the IAM grant.

## Context
Final pieces of the snapshot automation (manual dispatch already validated end-to-end and in production).
