### PR TITLE
DEVOPS-14811: sign keepalive commit via REST API so scheduled build stops failing

### DIFF
--- a/.github/workflows/buid-push-image.yaml
+++ b/.github/workflows/buid-push-image.yaml
@@ -115,12 +115,21 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
+      # Resets GitHub's 60-day scheduled-workflow inactivity timer (public repos only).
+      # Commits via the REST Contents API so GitHub signs them (web-flow) and they pass
+      # the "commits must have verified signatures" ruleset on main; plain git commits
+      # from the runner are unsigned and get rejected. Non-fatal: keepalive must never
+      # mask a real build result (the snapshot workflow gates on this run's success).
       - name: Keep workflow active
         if: always() && github.event_name == 'schedule'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          echo "Last workflow run: $(date -u)" > .github/.workflow-keep-alive
-          git add .github/.workflow-keep-alive
-          git diff --staged --quiet || git commit -m "chore: keep workflow active [skip ci]"
-          git push
+          CONTENT=$(date -u +"Last workflow run: %Y-%m-%dT%H:%M:%SZ")
+          SHA=$(gh api "repos/${{ github.repository }}/contents/.github/.workflow-keep-alive" --jq .sha 2>/dev/null || true)
+          gh api -X PUT "repos/${{ github.repository }}/contents/.github/.workflow-keep-alive" \
+            -f message="chore: keep workflow active [skip ci]" \
+            -f content="$(printf '%s' "$CONTENT" | base64 -w0)" \
+            ${SHA:+-f sha="$SHA"} \
+            -f branch=main


### PR DESCRIPTION
## Summary

The `Build and Push Docker Image` scheduled workflow is marked `failure` on every cron run (June 15, July 1, July 15) even though the image build+push succeeds. The `Keep workflow active` step creates an unsigned keepalive commit and `git push`es it to `main`, which the "commits must have verified signatures" ruleset rejects — failing the step and flipping the whole run to `failure`.

That blocks the EBS snapshot automation (`Build ghrunner EBS snapshot & open PR`), which gates on `workflow_run.conclusion == 'success'` and so skips instead of opening a bump PR.

## Fix

- Write the keepalive touch via the REST Contents API (`gh api`) instead of local `git`. Commits made through the API are signed by GitHub (`web-flow`) → Verified → pass the ruleset. Uses `GITHUB_TOKEN` only — no new secret, app, or third-party action.
- `continue-on-error: true` on the step so a keepalive hiccup can never again mask a real build result.

Keepalive can't simply be removed: this repo is public, so GitHub's 60-day scheduled-workflow inactivity timer applies, and only commits reset it (the step's commits were the repo's only activity for ~2.5 months earlier this year).

DEVOPS-14811
